### PR TITLE
set bintrayOrganization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ licenses          := Seq("BSD" -> url("http://opensource.org/licenses/BSD"))
 
 bintrayRepository := "sbt-plugins"
 
-bintrayOrganization := None
+bintrayOrganization := Some("typesafe")
 
 // this plugin depends on the sbt-osgi plugin -- 2-for-1!
 // TODO update to 0.8.0


### PR DESCRIPTION
@lrytz I had to do this in order for publishing 1.0.9 to succeed. is there some reason this isn't desirable or shouldn't be necessary?