### PR TITLE
Split jvm-specific settings into scalaModuleSettingsJVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,6 @@ bintrayRepository := "sbt-plugins"
 
 bintrayOrganization := None
 
-// this plugin depends on the sbt-osgi plugin -- 2-for-1!
-// TODO update to 0.8.0
-//      this might require us to modify the downstream project to enable the AutoPlugin
-//      See code changes and docs: https://github.com/sbt/sbt-osgi/commit/e3625e685b8d1784938ec66067d629251811a9d1
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")


### PR DESCRIPTION
Move jvm-specific settings from scalaModuleSettings to a new
scalaModuleSettingsJVM setting. This means that JVM projects in
scala modules now have to add bot `scalaModuleSettings` and
`scalaModuleSettingsJVM`.

Adding sbt-osgi settings in a scala-js project caused the published
jar to be empty (scala/scala-parser-combinators#119).

Upgrades sbt-osgi to the latest version.

Also anticipates the new optimizer settings in 2.12.3
(https://github.com/scala/scala/pull/5964).