### PR TITLE
Downgrade sbt-osgi to 0.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ bintrayRepository := "sbt-plugins"
 
 bintrayOrganization := None
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")
+// Version 0.9.1 requires Java 8 (on 6 we get NoClassDefFoundError: java/util/function/Predicate).
+// We still run our plugin builds for 2.11 on Java 6, so we cannot upgrade.
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")


### PR DESCRIPTION
Version 0.9.1 requires running sbt on Java 8. In our module builds we still
use Java 6 for building the against Scala 2.11.