### PR TITLE
Travis makes us work harder now to actually get OpenJDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 
 language: scala
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
 


### PR DESCRIPTION
as per:
https://github.com/travis-ci/travis-ci/issues/8199#issuecomment-327246053

an example Travis log showing us getting 8 even though we asked for 6 is https://travis-ci.org/scala/sbt-scala-module/builds/280149287?utm_source=github_status&utm_medium=notification