### PR TITLE
Only inline from current project sources under enableOptimizer

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -51,10 +51,11 @@ object ScalaModulePlugin extends AutoPlugin {
       }
       scalaVersions
     },
-
+    enableOptimizerInlineFrom := "<sources>",
     scalaVersion := crossScalaVersions.value.head
   )
 
+  val enableOptimizerInlineFrom = settingKey[String]("The value passed to -opt-inline-from by `enableOptimizer` on 2.13 and higher")
   /**
    * Enable `-opt:l:inline`, `-opt:l:classpath` or `-optimize`, depending on the scala version.
    */
@@ -63,8 +64,8 @@ object ScalaModulePlugin extends AutoPlugin {
     val Ver("2", maj, min) = scalaVersion.value
     (maj.toInt, min.toInt) match {
       case (m, _) if m < 12 => Seq("-optimize")
-      case (12, n) if n < 3 => Seq("-opt:l:classpath")
-      case _                => Seq("-opt:l:inline", "-opt-inline-from:scala/**")
+      case (12, n) if n < 3 => Seq("-opt:l:project")
+      case _                => Seq("-opt:l:inline", "-opt-inline-from:" + enableOptimizerInlineFrom.value)
     }
   }
 


### PR DESCRIPTION
Otherwise we can inline bytecode public, but unstable, artifacts
from the standard library, as was see in:

https://github.com/scala/scala/pull/6300#issuecomment-369141911

Tested as follows:

```
% sbt publish-local

% cd /code/scala-partest
diff --git a/project/plugins.sbt b/project/plugins.sbt
index 314c55a..df23fea 100644
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1 +1 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.13")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0-7aee2b537d30f227f2bb27ac6b1c09d5e94dcdf1")

% sbt
[info] Loading global plugins from /Users/jz/.sbt/0.13/plugins
[info] Loading project definition from /Users/jz/code/scala-partest/project
[info] Set current project to scala-partest (in build file:/Users/jz/code/scala-partest/)
> ++2.13.0-M2
[info] Setting version to 2.13.0-M2
[info] Reapplying settings...
[info] Set current project to scala-partest (in build file:/Users/jz/code/scala-partest/)
> show compile:compile::scalacOptions
[info] * -Xfatal-warnings
[info] * -feature
[info] * -deprecation
[info] * -unchecked
[info] * -Xlint
[info] * -opt:l:inline
[info] * -opt-inline-from:<sources>
[success] Total time: 0 s, completed 01/03/2018 11:19:54 AM
> set ScalaModulePlugin.enableOptimizerInlineFrom := "scala/*"
[info] Defining *:enableOptimizerInlineFrom
[info] The new value will be used by compile:compile::scalacOptions
[info] Reapplying settings...
[info] Set current project to scala-partest (in build file:/Users/jz/code/scala-partest/)
> show compile:compile::scalacOptions
[info] * -Xfatal-warnings
[info] * -feature
[info] * -deprecation
[info] * -unchecked
[info] * -Xlint
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/*
[success] Total time: 0 s, completed 01/03/2018 11:20:13 AM
> ++2.12.4
[info] Setting version to 2.12.4
[info] Reapplying settings...
[info] Set current project to scala-partest (in build file:/Users/jz/code/scala-partest/)
> show compile:compile::scalacOptions
[info] Updating {file:/Users/jz/code/scala-partest/}scala-partest...
[info] Resolving jline#jline;2.14.5 ...
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scalap/2.12.4/scalap-2.12.4.jar ...
[info]  [SUCCESSFUL ] org.scala-lang#scalap;2.12.4!scalap.jar (2784ms)
[info] Done updating.
[info] * -Xfatal-warnings
[info] * -feature
[info] * -deprecation
[info] * -unchecked
[info] * -Xlint
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/*
```