### PR TITLE
Upgrade SBT and bintray plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
-// incompatible with sbt-gpg (https://github.com/softprops/bintray-sbt/pull/10)
-//   JZ: is this still true after updating to 0.3.0?
-// lrytz: I tried upgrading to "org.foundweekends" % "sbt-bintray" % "0.4.0" but got a linkage error
-//   [error] (*:bintrayEnsureBintrayPackageExists) java.lang.NoSuchMethodError: org.json4s.Formats.emptyValueStrategy()Lorg/json4s/prefs/EmptyValueStrategy;
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")


### PR DESCRIPTION
I'm not seeing the incompatibility with sbt-pgp 1.1.1.

I tested by adding that as a global plugin:

```
// ~/.sbt/0.13/plugins/plugins.sbt
addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
```

And then, on this branch:

```
⚡ sbt
[info] Loading global plugins from /Users/jz/.sbt/0.13/plugins
[info] Updating {file:/Users/jz/.sbt/0.13/plugins/}global-plugins...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.jsuereth/sbt-pgp/scala_2.10/sbt_0.13/1.1.1/jars/sbt-pgp.jar ...
[info] 	[SUCCESSFUL ] com.jsuereth#sbt-pgp;1.1.1!sbt-pgp.jar (9646ms)
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.jsuereth/pgp-library_2.10/1.1.1/jars/pgp-library_2.10.jar ...
[info] 	[SUCCESSFUL ] com.jsuereth#pgp-library_2.10;1.1.1!pgp-library_2.10.jar (9047ms)
[info] downloading https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-okhttp_2.10/0.3.0/gigahorse-okhttp_2.10-0.3.0.jar ...
[info] 	[SUCCESSFUL ] com.eed3si9n#gigahorse-okhttp_2.10;0.3.0!gigahorse-okhttp_2.10.jar (1553ms)
[info] downloading https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.10/0.3.0/gigahorse-core_2.10-0.3.0.jar ...
[info] 	[SUCCESSFUL ] com.eed3si9n#gigahorse-core_2.10;0.3.0!gigahorse-core_2.10.jar (1020ms)
[info] downloading https://repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.10/0.2.2/ssl-config-core_2.10-0.2.2.jar ...
[info] 	[SUCCESSFUL ] com.typesafe#ssl-config-core_2.10;0.2.2!ssl-config-core_2.10.jar(bundle) (1062ms)
[info] Done updating.
[info] Loading project definition from /Users/jz/code/sbt-scala-module/project
[info] Updating {file:/Users/jz/code/sbt-scala-module/project/}sbt-scala-module-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Set current project to sbt-scala-module (in build file:/Users/jz/code/sbt-scala-module/)
> plugins
In file:/Users/jz/code/sbt-scala-module/
	sbt.plugins.IvyPlugin: enabled in sbt-scala-module
	sbt.plugins.JvmPlugin: enabled in sbt-scala-module
	sbt.plugins.CorePlugin: enabled in sbt-scala-module
	sbt.plugins.JUnitXmlReportPlugin: enabled in sbt-scala-module
	sbt.plugins.Giter8TemplatePlugin: enabled in sbt-scala-module
	com.typesafe.sbt.SbtPgp: enabled in sbt-scala-module
	sbt.plugins.BackgroundRunPlugin: enabled in sbt-scala-module
	sbt.plugins.InteractionServicePlugin: enabled in sbt-scala-module
	sbt.plugins.SendEventServicePlugin: enabled in sbt-scala-module
	sbt.plugins.SerializersPlugin: enabled in sbt-scala-module
	bintray.BintrayPlugin: enabled in sbt-scala-module
	io.github.retronym.SbtArgsFilePlugin: enabled in sbt-scala-module
	io.github.retronym.RawCompile: enabled in sbt-scala-module
> publish
[info] Packaging /Users/jz/code/sbt-scala-module/target/scala-2.10/sbt-0.13/sbt-scala-module-1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e-sources.jar ...
[info] Updating {file:/Users/jz/code/sbt-scala-module/}sbt-scala-module...
[info] Done packaging.
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] :: delivering :: org.scala-lang.modules#sbt-scala-module;1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e :: 1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e :: release :: Sun Apr 08 14:53:55 AEST 2018
[info] 	delivering ivy file to /Users/jz/code/sbt-scala-module/target/scala-2.10/sbt-0.13/ivy-1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e.xml
[info] Packaging /Users/jz/code/sbt-scala-module/target/scala-2.10/sbt-0.13/sbt-scala-module-1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e-javadoc.jar ...
[info] Packaging /Users/jz/code/sbt-scala-module/target/scala-2.10/sbt-0.13/sbt-scala-module-1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e.jar ...
[info] Done packaging.
[info] Done packaging.
[info] 	published sbt-scala-module to org.scala-lang.modules/sbt-scala-module/scala_2.10/sbt_0.13/1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e/jars/sbt-scala-module.jar
[info] 	published sbt-scala-module to org.scala-lang.modules/sbt-scala-module/scala_2.10/sbt_0.13/1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e/srcs/sbt-scala-module-sources.jar
[info] 	published sbt-scala-module to org.scala-lang.modules/sbt-scala-module/scala_2.10/sbt_0.13/1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e/docs/sbt-scala-module-javadoc.jar
[info] 	published ivy to org.scala-lang.modules/sbt-scala-module/scala_2.10/sbt_0.13/1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e/ivys/ivy.xml
[info] retronym/sbt-scala-module@1.0-85edb147d31aff4bc9150c29d94b8bc62f56206e was released
[success] Total time: 22 s, completed 08/04/2018 2:54:14 PM
```