### PR TITLE
Avoid creating 'dummy' mimaPreviousArtifacts value

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -176,7 +176,7 @@ object ScalaModulePlugin extends AutoPlugin {
     mimaPreviousVersion := None,
 
     // We're not using `%%` here in order to support both jvm and js projects (cross version `_2.12` / `_sjs0.6_2.12`)
-    mimaPreviousArtifacts := Set(organization.value % moduleName.value % mimaPreviousVersion.value.getOrElse("dummy") cross crossVersion.value),
+    mimaPreviousArtifacts := mimaPreviousVersion.value.map(organization.value % moduleName.value % _ cross crossVersion.value).toSet,
 
     canRunMima := {
       val mimaVer = mimaPreviousVersion.value
@@ -194,7 +194,7 @@ object ScalaModulePlugin extends AutoPlugin {
     },
 
     runMimaIfEnabled := Def.taskDyn({
-      if(canRunMima.value) Def.task { mimaReportBinaryIssues.value }
+      if (canRunMima.value) Def.task { mimaReportBinaryIssues.value }
       else Def.task { () }
     }).value,
 

--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -179,17 +179,17 @@ object ScalaModulePlugin extends AutoPlugin {
     mimaPreviousArtifacts := mimaPreviousVersion.value.map(organization.value % moduleName.value % _ cross crossVersion.value).toSet,
 
     canRunMima := {
-      val mimaVer = mimaPreviousVersion.value
       val s = streams.value
       val ivySbt = Keys.ivySbt.value
-      if (mimaVer.isEmpty) {
-        s.log.warn("MiMa will NOT run because no mimaPreviousVersion is provided.")
-        false
-      } else if (!artifactExists(organization.value, name.value, scalaBinaryVersion.value, mimaVer.get, ivySbt, s)) {
-        s.log.warn(s"""MiMa will NOT run because the previous artifact "${organization.value}" % "${name.value}_${scalaBinaryVersion.value}" % "${mimaVer.get}" could not be resolved (note the binary Scala version).""")
-        false
-      } else {
-        true
+      mimaPreviousVersion.value match {
+        case None =>
+          s.log.warn("MiMa will NOT run because no mimaPreviousVersion is provided.")
+          false
+        case Some(mimaPrevVer) if !artifactExists(organization.value, name.value, scalaBinaryVersion.value, mimaPrevVer, ivySbt, s) =>
+          s.log.warn(s"""MiMa will NOT run because the previous artifact "${organization.value}" % "${name.value}_${scalaBinaryVersion.value}" % "$mimaPrevVer" could not be resolved (note the binary Scala version).""")
+          false
+        case _ =>
+          true
       }
     },
 


### PR DESCRIPTION
Applying this PR will:

- avoid creating the 'dummy' mimaPreviousArtifacts value, fixes #53
- avoid an Option.get in the canRunMima-logic