### PR TITLE
Drop scalaVersionsByJvm and add sbt-travisci

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,6 @@ repoName     := "<GitHub repo name>" // the repo under github.com/scala/, only r
 organization := "<org>"              // only required if different from "org.scala-lang.modules"
 version      := "<module version>"
 
-// The plugin uses `scalaVersionsByJvm` to set `crossScalaVersions in ThisBuild` according to the JVM major version.
-// The `scalaVersion in ThisBuild` is set to `crossScalaVersions.value.head`.
-scalaVersionsByJvm in ThisBuild := {
-  val v211 = "2.11.12"
-  val v212 = "2.12.8"
-  val v213 = "2.13.0-RC1"
-  // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
-  Map(
-    8 -> List(v211 -> true, v212 -> true, v213 -> true),
-    9 -> List(v211, v212, v213).map(_ -> false))
-}
-
 mimaPreviousVersion := Some("1.0.0") // enables MiMa (`None` by default, which disables it)
 
 OsgiKeys.exportPackage := Seq(s"<exported package>;version=${version.value}")

--- a/build.sbt
+++ b/build.sbt
@@ -9,3 +9,4 @@ licenses            := Seq(("Apache-2.0", url("https://www.apache.org/licenses/L
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.5.0")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")


### PR DESCRIPTION
Applying this PR will:

- drop `scalaVersionsByJvm` because we have the alternative of tag based publishing
- add sbt-travisci to base the values for `crossScalaVersions` and `scalaVersion` on the scala versions defined in the `travis.yml` file

projects still using `scalaVersionsByJvm` listed below, maybe migrate them to tag based publishing first:
- [ ] [scala-async](https://github.com/scala/scala-async)
- [ ] [scala-collection-compat](https://github.com/scala/scala-collection-compat)
- [ ] [scala-continuations](https://github.com/scala/scala-continuations)
- [ ] [scala-parallel-collections](https://github.com/scala/scala-parallel-collections)
- [ ] [scala-partest](https://github.com/scala/scala-partest)
- [ ] [scala-swing](https://github.com/scala/scala-swing)

ping @SethTisue @dwijnand 