### PR TITLE
use sbt-dynver, sbt-ci-release, sbt-travisci

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 enablePlugins(SbtPlugin)
 
-git.baseVersion   := "2.0.0"
-versionWithGit
-
 name                := "sbt-scala-module"
 organization        := "org.scala-lang.modules"
 licenses            := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.5.0")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")   // set scalaVersion and crossScalaVersions
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.1") // set version, scmInfo, publishing settings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")


### PR DESCRIPTION
Use sbt-dynver, sbt-ci-release, sbt-travisci for modules.

Here's how it would look once in use: https://github.com/scala/scala-parallel-collections/compare/master...lrytz:ci-release

I tested things to some degree :-) But opening the PR now to gather some feedback.

What I tested
  - Use the scala-parallel-collections branch with a `publishLocal`'d version of the sbt-scala-module
  - Tested the build script in scala-parallel-collections in https://github.com/lrytz/travis-test
