### PR TITLE
Update SBT OSGI Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name                := "sbt-scala-module"
 organization        := "org.scala-lang.modules"
 licenses            := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")))
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.0")
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")   // set scalaVersion and crossScalaVersions


### PR DESCRIPTION
Projects will not build on JRE 15 with the current version due to an old bug in a dependency of `sbt-osgi`.

See: https://github.com/sbt/sbt-osgi/pull/72 and https://github.com/bndtools/bnd/issues/3903

Note: This PR should not be merged until https://github.com/sbt/sbt-osgi/pull/72 is merged and sbt-osgi does a release. It won't build until then.