### PR TITLE
Don't make ScalaModulePlugin.enableOptimizer fail on Scala3

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -50,11 +50,12 @@ object ScalaModulePlugin extends AutoPlugin {
    */
   lazy val enableOptimizer: Setting[_] = Compile / compile / scalacOptions ++= {
     val Ver = """(\d+)\.(\d+)\.(\d+).*""".r
-    val Ver("2", maj, min) = scalaVersion.value
-    (maj.toInt, min.toInt) match {
-      case (m, _) if m < 12 => Seq("-optimize")
-      case (12, n) if n < 3 => Seq("-opt:l:project")
-      case _                => Seq("-opt:l:inline", "-opt-inline-from:" + scalaModuleEnableOptimizerInlineFrom.value)
+    val Ver(epic, maj, min) = scalaVersion.value
+    (epic, maj.toInt, min.toInt) match {
+      case ("2", m, _) if m < 12 => Seq("-optimize")
+      case ("2", 12, n) if n < 3 => Seq("-opt:l:project")
+      case ("2", _, _)           => Seq("-opt:l:inline", "-opt-inline-from:" + scalaModuleEnableOptimizerInlineFrom.value)
+      case ("3", _, _)           => Nil // Optimizer not yet available for Scala3, see https://docs.scala-lang.org/overviews/compiler-options/optimizer.html
     }
   }
 


### PR DESCRIPTION
If you use `ScalaModulePlugin.enableOptimizer` on a project which happens to compile for Scala3 then it fails to load the SBT project because it assumes you are only using Scala2, you end up getting the following error

```
[error] scala.MatchError: 3.2.0 (of class java.lang.String)
[error] 	at com.lightbend.tools.scalamoduleplugin.ScalaModulePlugin$.$anonfun$enableOptimizer$1(ScalaModulePlugin.scala:53)
```

The PR updates `enableOptimizer` so that it works with projects that target Scala3 (note that Scala3 does not yet have an inlining optimizer, this has been noted).