### PR TITLE
Only enable optimizer in CI

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -46,7 +46,11 @@ object ScalaModulePlugin extends AutoPlugin {
   )
 
   /**
-   * Enable `-opt:l:inline`, `-opt:l:project` or `-optimize`, depending on the scala version.
+   * Enable `-opt:l:inline`, `-opt:l:project` or `-optimize`, depending on the Scala version.
+   *
+   * Note that the optimizer is only enabled in CI and not during local development.
+   * Thus, for consistent results, release artifacts must only be built on CI --
+   * which is the expected norm for Scala modules, anyway.
    */
   lazy val enableOptimizer: Setting[_] = Compile / compile / scalacOptions ++= {
     if (insideCI.value) {


### PR DESCRIPTION
From https://docs.scala-lang.org/overviews/compiler-options/optimizer.html#in-brief

> Don’t enable the optimizer during development: it breaks incremental compilation, and it makes the compiler slower. Only enable it for testing, on CI, and to build releases.

This PR makes it so that the Scala 2 optimizer is only enabled in CI since it causes issues when used in local development with additional logging to make it clear when its enabled.

Note That there is a presumption in that Scala modules that use this sbt-plugin do their releases in CI rather than a local machine. @SethTisue would be good to check if this is the case, if not then then let me know which Scala modules don't use CI for release and I can look into enabling it (I do think that by now all Scala modules should be creating release artifacts in CI).