### PR TITLE
Fix tagged releases being versioned as SNAPSHOTs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
         java-version: 8
     - uses: sbt/setup-sbt@v1
     - name: Test
-      run: sbt test
+      run: sbt test scripted

--- a/build.sbt
+++ b/build.sbt
@@ -10,3 +10,6 @@ addSbtPlugin("com.github.sbt" % "sbt-osgi" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.1") // set version, scmInfo, publishing settings
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")  // brings in MiMa
+
+scriptedLaunchOpts += s"-Dplugin.version=${version.value}"
+scriptedBufferLog := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.14
+sbt.version=1.13.0

--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -5,7 +5,6 @@ import sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense}
 import sbt.Keys._
 import sbt.{Def, _}
 import sbtdynver.DynVerPlugin
-import sbtdynver.DynVerPlugin.autoImport.dynverGitDescribeOutput
 import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.{Compatibility, versionPolicyCheck, versionPolicyIgnoredInternalDependencyVersions, versionPolicyIntention}
 
 object ScalaModulePlugin extends AutoPlugin {
@@ -18,7 +17,7 @@ object ScalaModulePlugin extends AutoPlugin {
   }
   import autoImport._
 
-  // depend on DynVerPlugin to allow modifying dynverGitDescribeOutput in buildSettings below
+  // modules are versioned by dynver, and this brings in JvmPlugin (sbt/sbt#2082)
   override def requires = DynVerPlugin
 
   override def trigger = allRequirements
@@ -26,10 +25,6 @@ object ScalaModulePlugin extends AutoPlugin {
   // Settings in here are implicitly `in ThisBuild`
   override def buildSettings: Seq[Setting[?]] = Seq(
     scalaModuleEnableOptimizerInlineFrom := "<sources>",
-
-    // drop # suffix from tags
-    dynverGitDescribeOutput ~= (_.map(dv =>
-      dv.copy(ref = sbtdynver.GitRef(dv.ref.value.split('#').head)))),
   )
 
   // Settings added to the project scope

--- a/src/sbt-test/scala-module/version-from-tag/build.sbt
+++ b/src/sbt-test/scala-module/version-from-tag/build.sbt
@@ -1,0 +1,22 @@
+import complete.DefaultParsers._
+
+val checkRelease = inputKey[Unit]("Assert a clean release version derived from a tag")
+val checkSnapshot = inputKey[Unit]("Assert a snapshot version with the given prefix")
+
+lazy val root = project.in(file(".")).settings(
+  checkRelease := {
+    val expected = spaceDelimited("<version>").parsed.head
+    val actual = version.value
+    assert(actual == expected, s"expected version '$expected', got '$actual'")
+    assert(!isSnapshot.value, s"expected a release, but isSnapshot is true (version '$actual')")
+    // sbt-dynver >= 5.1.1 only reports isTag for the GitTag subclass it parses itself
+    assert(dynverGitDescribeOutput.value.exists(_.ref.isTag), "expected dynver to detect a tag")
+  },
+
+  checkSnapshot := {
+    val prefix = spaceDelimited("<prefix>").parsed.head
+    val actual = version.value
+    assert(actual.startsWith(prefix) && actual.endsWith("-SNAPSHOT"), s"expected version '$prefix...-SNAPSHOT', got '$actual'")
+    assert(isSnapshot.value, s"expected a snapshot, but isSnapshot is false (version '$actual')")
+  }
+)

--- a/src/sbt-test/scala-module/version-from-tag/project/plugins.sbt
+++ b/src/sbt-test/scala-module/version-from-tag/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % v)
+  case None    => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/src/sbt-test/scala-module/version-from-tag/test
+++ b/src/sbt-test/scala-module/version-from-tag/test
@@ -1,0 +1,20 @@
+$ exec git init .
+$ exec git config user.email scala-module@example.org
+$ exec git config user.name scala-module
+$ exec git config commit.gpgSign false
+$ exec git commit --allow-empty -m release
+
+# a clean tagged checkout publishes as a release, not a SNAPSHOT
+$ exec git tag v1.2.3
+> reload
+> checkRelease 1.2.3
+
+# a commit after the tag publishes as a SNAPSHOT
+$ exec git commit --allow-empty -m after-tag
+> reload
+> checkSnapshot 1.2.3+1-
+
+# legacy back-publishing tags: sbt-ci-release drops the '#' suffix
+$ exec git tag v1.3.0#2.13.0
+> reload
+> checkRelease 1.3.0


### PR DESCRIPTION
sbt-dynver 5.1.1 changed GitRef.isTag to a type test for its own
package-private GitTag subclass, so rewriting dynverGitDescribeOutput to
strip the `#` suffix downgraded the parsed tag to a plain GitRef: dynver
then saw no tag and derived `<tag>+0-<sha>-SNAPSHOT`.

The rewrite is no longer needed. sbt-ci-release's own ThisBuild / version
already drops `#` (and `@`) suffixes, keeping the distance/dirty suffix,
and the `#` tag scheme it was written for was superseded by
sbt-ci-release's `@` back-publishing.
